### PR TITLE
Prepare site for vertigis.com domain

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
     title: "Meridian Design System",
     tagline: "Navigating to Consistency",
     url: "https://meridian.vertigis.com",
-    baseUrl: "/meridian-design/",
+    baseUrl: "/",
     noIndex: true,
     favicon: "img/favicon.ico",
     organizationName: "geocortex",


### PR DESCRIPTION
Updates the `baseUrl` path to `/` to match `meridian.vertigis.com`.